### PR TITLE
Add CI builds using GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # build the master branch every Monday morning
+    - cron: '57 5 * * 1'
+  workflow_dispatch:
+
+jobs:
+  build-latest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        compiler: [cc, clang, gcc-12]
+        os: [ubuntu-latest, macos-latest]
+        exclude:
+          - os: macos-latest
+            compiler: cc
+          - os: macos-latest
+            compiler: gcc-12
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run autotools
+        run: |
+          autoheader
+          autoconf
+      - name: Compiler version
+        run: $CC -v
+        env:
+          CC: ${{ matrix.compiler }}
+      - name: configure
+        run: ./configure
+        env:
+          CC: ${{ matrix.compiler }}
+      - name: make
+        run: make -k
+      - name: Run unit tests
+        run: ./bgpdump -T
+      - name: Regression tests
+        run: ./test.sh


### PR DESCRIPTION
As mentioned in #13, CI matrix builds: On Linux using GCC (default version, currently 11), Clang (default version, currently 14) and GCC 12 (there is currently no more recent version in Ubuntu). Additionally on macOS using Clang (default version, currently 14).