### PR TITLE
OS conditionals and dependency installs for runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Check OS name
+        run: echo "The operating system on the runner is $RUNNER_OS."
+      - name: Install dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libbz2-dev zlib1g-dev
+      - name: Install autotools
+        if: runner.os == 'macOS'
+        run: brew install autoconf
       - name: Run autotools
         run: |
           autoheader

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    - name: Install application build dependencies
+      run: sudo apt-get install libbz2-dev zlib1g-dev
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:


### PR DESCRIPTION
- the macOS runners no longer come with autotools installed by default
- the ubuntu runners no longer come with zlib or bz2 headers installed by default