### PR TITLE
Add extended BGP community parsing and decoding support

### DIFF
--- a/bgpdump.c
+++ b/bgpdump.c
@@ -1408,6 +1408,9 @@ void show_attr(attributes_t *attr) {
 
         if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_LARGE_COMMUNITIES) ) !=0)    
             printf("LARGE_COMMUNITY:%s\n",attr->lcommunity->str);
+
+        if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES) ) !=0)    
+            printf("EXT_COMMUNITY:%s\n",attr->ecommunity->str);
        
     }
  
@@ -1581,6 +1584,11 @@ static void table_line_announce(struct prefix *prefix,int count,BGPDUMP_ENTRY *e
                     printf("|");
             }
 
+            if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES) ) !=0)	
+                printf("%s|",entry->attr->ecommunity->str+1);
+            else
+                printf("|");
+
 		    printf("%s|", aggregate); /* AG/NAG */
 
 			if (entry->attr->aggregator_addr.s_addr != -1) {
@@ -1687,6 +1695,11 @@ static void table_line_announce_1(struct mp_nlri *prefix,int count,BGPDUMP_ENTRY
                         printf("|");
                 }
 
+                if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES) ) !=0)	
+                    printf("%s|",entry->attr->ecommunity->str+1);
+                else
+                    printf("|");
+
                 printf("%s|", aggregate); /* AG/NAG */
 
 			}
@@ -1738,6 +1751,11 @@ static void table_line_announce_1(struct mp_nlri *prefix,int count,BGPDUMP_ENTRY
                     else
                         printf("|");
                 }
+
+                if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES) ) !=0)	
+                    printf("%s|",entry->attr->ecommunity->str+1);
+                else
+                    printf("|");
 
                 printf("%s|",aggregate); /* AG/NAG */
 
@@ -1857,6 +1875,11 @@ static void table_line_announce6(struct mp_nlri *prefix,int count,BGPDUMP_ENTRY 
                     printf("|");
 
             }
+
+            if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES) ) !=0)	
+                printf("%s|",entry->attr->ecommunity->str+1);
+            else
+                printf("|");
 
             printf("%s|", aggregate); /* AG/NAG */
 
@@ -1980,6 +2003,11 @@ static void table_line_mrtd_route(BGPDUMP_MRTD_TABLE_DUMP *route,BGPDUMP_ENTRY *
                     printf("|");
 
             }
+
+            if( (entry->attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES) ) !=0)	
+                printf("%s|",entry->attr->ecommunity->str+1);
+            else
+                printf("|");
 
             printf("%s|",aggregate); /* AG/NAG */
 				
@@ -2114,6 +2142,11 @@ static void table_line_dump_v2_prefix(BGPDUMP_TABLE_DUMP_V2_PREFIX *e,BGPDUMP_EN
                 else
                     printf("|");
             }
+
+            if( (attr->flag & ATTR_FLAG_BIT(BGP_ATTR_EXT_COMMUNITIES) ) !=0)	
+                printf("%s|",attr->ecommunity->str+1);
+            else
+                printf("|");
             
             printf("%s|",aggregate);
 

--- a/bgpdump_attr.h
+++ b/bgpdump_attr.h
@@ -165,6 +165,13 @@ struct lcommunity
   char      *str;
 };
 
+struct ecommunity
+{
+  int       size;
+  u_int8_t  *val;
+  char      *str;
+};
+
 struct cluster_list
 {
   int			length;


### PR DESCRIPTION
- Define ecommunity structure in bgpdump_attr.h
- Add parsing for BGP_ATTR_EXT_COMMUNITIES attribute (type 16)
- Implement process_attr_ecommunity_string() for formatting extended communities
- Support AS format (RT/RO with AS:value) and IP format (RT/RO with IP:value)
- Add extended community display in all output formats
- Add proper memory management for ecommunity structures